### PR TITLE
Split pages in TrinoExchangeSource for parallel execution.

### DIFF
--- a/cpp/src/TrinoExchangeSource.cpp
+++ b/cpp/src/TrinoExchangeSource.cpp
@@ -275,7 +275,7 @@ void TrinoExchangeSource::processDataResponse(
     auto curr = singleChain.get();
     while (remaingPage) {
       if (!curr) {
-        VLOG(google::ERROR) << "Recived page body in TrinoExchangeSource is corrupted.";
+        VLOG(google::ERROR) << "Received page body in TrinoExchangeSource is corrupted.";
       }
 
       readIOBuf(pageHeader, curr, TRINO_SERIALIZED_PAGE_HEADER_SIZE + 4);

--- a/cpp/src/TrinoExchangeSource.cpp
+++ b/cpp/src/TrinoExchangeSource.cpp
@@ -320,11 +320,11 @@ void TrinoExchangeSource::processDataResponse(
   }
 
   std::vector<ContinuePromise> promises;
-  for (auto&& page : pages) {
-    REPORT_ADD_HISTOGRAM_VALUE(kCounterPrestoExchangeSerializedPageSize,
-                               page ? page->size() : 0);
-    {
-      std::lock_guard<std::mutex> l(queue_->mutex());
+  {
+    std::lock_guard<std::mutex> l(queue_->mutex());
+    for (auto&& page : pages) {
+      // REPORT_ADD_HISTOGRAM_VALUE(kCounterPrestoExchangeSerializedPageSize,
+      //                            page ? page->size() : 0);
       if (page) {
         VLOG(1) << "Enqueuing page for " << basePath_ << "/" << sequence_ << ": "
                 << page->size() << " bytes";

--- a/cpp/src/TrinoExchangeSource.h
+++ b/cpp/src/TrinoExchangeSource.h
@@ -100,6 +100,6 @@ class TrinoExchangeSource : public facebook::velox::exec::ExchangeSource {
   // successfully processed by the remote server.
   std::atomic_bool abortResultsSucceeded_{false};
 
-  folly::CPUThreadPoolExecutor* driverThreadPool_{nullptr};
+  folly::ThreadPoolExecutor* threadPool_{nullptr};
 };
 }  // namespace io::trino::bridge

--- a/cpp/src/serialization/TrinoSerializer.cpp
+++ b/cpp/src/serialization/TrinoSerializer.cpp
@@ -765,11 +765,12 @@ class TrinoVectorSerializer : public facebook::velox::VectorSerializer {
     writeInt32(out, streams_.size());
 
     if (rle) {
+      VLOG(google::ERROR) << "RLE is not supported.";
       // Write RLE encoding marker.
-      writeInt32(out, kRLE.size());
-      out->write(kRLE.data(), kRLE.size());
-      // Write number of RLE values.
-      writeInt32(out, numRows);
+      // writeInt32(out, kRLE.size());
+      // out->write(kRLE.data(), kRLE.size());
+      // // Write number of RLE values.
+      // writeInt32(out, numRows);
     }
 
     for (auto& stream : streams_) {
@@ -1160,9 +1161,9 @@ void readTimestampWithTimeZone(ByteStream* source,
     }
   }
 
-  *result =
-      std::make_shared<RowVector>(pool, TIMESTAMP_WITH_TIME_ZONE(), timestamps->nulls(),
-                                  size, std::vector<VectorPtr>{timestamps, std::move(timezones)});
+  *result = std::make_shared<RowVector>(
+      pool, TIMESTAMP_WITH_TIME_ZONE(), timestamps->nulls(), size,
+      std::vector<VectorPtr>{timestamps, std::move(timezones)});
 }
 
 void readRowVector(ByteStream* source, std::shared_ptr<const Type> type,

--- a/cpp/src/utils/HttpClient.h
+++ b/cpp/src/utils/HttpClient.h
@@ -13,6 +13,7 @@
  */
 #pragma once
 #include <folly/futures/Future.h>
+#include <folly/io/IOBufQueue.h>
 #include <proxygen/lib/http/HTTPConnector.h>
 #include <proxygen/lib/http/connpool/SessionPool.h>
 #include <proxygen/lib/http/session/HTTPUpstreamSession.h>
@@ -56,7 +57,7 @@ class HttpResponse {
   /// Consumes the response body. The caller is responsible for freeing the
   /// backed memory of this IOBuf from MappedMemory. Otherwise it could lead to
   /// memory leak.
-  std::vector<std::unique_ptr<folly::IOBuf>> consumeBody() {
+  folly::IOBufQueue consumeBody() {
     VELOX_CHECK(!hasError());
     return std::move(bodyChain_);
   }
@@ -82,7 +83,7 @@ class HttpResponse {
   const uint64_t maxResponseAllocBytes_;
 
   std::string error_{};
-  std::vector<std::unique_ptr<folly::IOBuf>> bodyChain_;
+  folly::IOBufQueue bodyChain_;
   size_t bodyChainBytes_{0};
 };
 

--- a/cpp/src/utils/HttpConstants.h
+++ b/cpp/src/utils/HttpConstants.h
@@ -22,4 +22,16 @@ const uint16_t kHttpInternalServerError = 500;
 
 const char kMimeTypeApplicationJson[] = "application/json";
 const char kMimeTypeApplicationThrift[] = "application/x-thrift+binary";
-} // namespace facebook::presto::http
+
+#define TRINO_RESULT_RESPONSE_HEADER_LEN 16
+#define TRINO_RESULT_RESPONSE_HEADER_MAGIC 0xfea4f001
+#define TRINO_SERIALIZED_PAGE_HEADER_SIZE 13
+#define TRINO_SERIALIZED_PAGE_ROW_NUM_OFFSET 0
+#define TRINO_SERIALIZED_PAGE_CODEC_OFFSET (TRINO_SERIALIZED_PAGE_ROW_NUM_OFFSET + 4)
+#define TRINO_SERIALIZED_PAGE_UNCOMPRESSED_SIZE_OFFSET \
+  (TRINO_SERIALIZED_PAGE_CODEC_OFFSET + 1)
+#define TRINO_SERIALIZED_PAGE_COMPRESSED_SIZE_OFFSET \
+  (TRINO_SERIALIZED_PAGE_UNCOMPRESSED_SIZE_OFFSET + 4)
+#define TRINO_SERIALIZED_PAGE_COL_NUM_OFFSET \
+  (TRINO_SERIALIZED_PAGE_COMPRESSED_SIZE_OFFSET + 4)
+}  // namespace io::trino::bridge::http


### PR DESCRIPTION
In the previous implementation, all pages in a result response are not split, which leads to them being only assigned to a single driver. To increase the parallelism, this PR splits the pages in a result response.

Pls take a review @wuxueyang96