### PR TITLE
Remove several unused maven dependency to fix issues reported by security bot

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -756,7 +756,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.1.214</version>
+                <version>2.2.220</version>
             </dependency>
 
             <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -643,19 +643,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.clickhouse</groupId>
-                <artifactId>clickhouse-jdbc</artifactId>
-                <version>0.4.1</version>
-                <classifier>all</classifier>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>com.databricks</groupId>
                 <artifactId>databricks-jdbc</artifactId>
                 <version>2.6.29</version>
@@ -1313,12 +1300,6 @@
                 <groupId>org.pcollections</groupId>
                 <artifactId>pcollections</artifactId>
                 <version>2.1.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>42.5.0</version>
             </dependency>
 
             <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1374,14 +1374,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
-            <!-- Transitive dependency from jackson-dataformat-yaml. Avoid different versions being used -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -754,12 +754,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>2.2.220</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.linkedin.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
                 <version>1.21.0.152</version>
@@ -1193,11 +1187,6 @@
                 </exclusions>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.ivy</groupId>
-                <artifactId>ivy</artifactId>
-                <version>2.5.1</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -854,18 +854,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>3.0.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio-jvm</artifactId>
-                <version>3.3.0</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.squareup.wire</groupId>
                 <artifactId>wire-runtime-jvm</artifactId>
                 <version>${dep.wire.version}</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -51,7 +51,6 @@
         <dep.minio.version>7.1.4</dep.minio.version>
         <dep.iceberg.version>1.1.0</dep.iceberg.version>
         <dep.spotbugs-annotations.version>4.7.2</dep.spotbugs-annotations.version>
-        <dep.protobuf.version>3.21.6</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
         <dep.kotlin.version>1.8.0</dep.kotlin.version>
         <dep.netty.version>4.1.79.Final</dep.netty.version>
@@ -739,18 +738,6 @@
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
                 <version>${dep.errorprone.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${dep.protobuf.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java-util</artifactId>
-                <version>${dep.protobuf.version}</version>
             </dependency>
 
             <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -952,11 +952,6 @@
 
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>3.9.8.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>4.1.72.Final</version>
             </dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -907,28 +907,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>4.1.72.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver</artifactId>
-                <version>4.1.72.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>4.1.72.Final</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.72.Final</version>
-            </dependency>
-
-            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>1.6.2</version>


### PR DESCRIPTION
It includes:
- protobuf
- clickhouse-jdbc
- protobuf-java
- protobuf-java-util
- h2
- okio
- okio-jvm
- netty
- ivy
- postgresql
- snakeyaml

Issues incl: 
https://github.com/oap-project/Gluten-Trino/security/dependabot/25
https://github.com/oap-project/Gluten-Trino/security/dependabot/28
https://github.com/oap-project/Gluten-Trino/security/dependabot/26
https://github.com/oap-project/Gluten-Trino/security/dependabot/36
https://github.com/oap-project/Gluten-Trino/security/dependabot/34
https://github.com/oap-project/Gluten-Trino/security/dependabot/32
https://github.com/oap-project/Gluten-Trino/security/dependabot/23
https://github.com/oap-project/Gluten-Trino/security/dependabot/22
https://github.com/oap-project/Gluten-Trino/security/dependabot/21
https://github.com/oap-project/Gluten-Trino/security/dependabot/35
https://github.com/oap-project/Gluten-Trino/security/dependabot/33
https://github.com/oap-project/Gluten-Trino/security/dependabot/30
https://github.com/oap-project/Gluten-Trino/security/dependabot/29
https://github.com/oap-project/Gluten-Trino/security/dependabot/27
https://github.com/oap-project/Gluten-Trino/security/dependabot/24
https://github.com/oap-project/Gluten-Trino/security/dependabot/19