### PR TITLE
enable spill config, refactor fetch output

### DIFF
--- a/cpp/src/NativeConfigs.cpp
+++ b/cpp/src/NativeConfigs.cpp
@@ -51,7 +51,14 @@ NativeConfigs::NativeConfigs(const std::string& configJsonString) {
   GET_KEY_FROM_JSON(reservedMemoryPoolCapacityPercentage, configJson);
   GET_KEY_FROM_JSON(initMemoryPoolCapacity, configJson);
   GET_KEY_FROM_JSON(minMemoryPoolTransferCapacity, configJson);
-  GET_KEY_FROM_JSON(maxHttpSessionReadBufferSize, configJson);
+  GET_KEY_FROM_JSON(spillEnabled, configJson);
+  GET_KEY_FROM_JSON(joinSpillEnabled, configJson);
+  GET_KEY_FROM_JSON(aggSpillEnabled, configJson);
+  GET_KEY_FROM_JSON(orderBySpillEnabled, configJson);
+  GET_KEY_FROM_JSON(spillDir, configJson);
+  GET_KEY_FROM_JSON(joinSpillMemoryThreshold, configJson);
+  GET_KEY_FROM_JSON(aggregationSpillMemoryThreshold, configJson);
+  GET_KEY_FROM_JSON(orderBySpillMemoryThreshold, configJson);
 
   if (configJson.contains("logVerboseModules")) {
     std::string _logVerboseModules;
@@ -95,8 +102,19 @@ NativeConfigs::NativeConfigs(const std::string& configJsonString) {
 }
 
 std::unordered_map<std::string, std::string> NativeConfigs::getQueryConfigs() const {
-  return {{core::QueryConfig::kMaxPartitionedOutputBufferSize,
-           std::to_string(getMaxOutputPageBytes())}};
+  return {
+      {core::QueryConfig::kMaxPartitionedOutputBufferSize,
+       std::to_string(getMaxOutputPageBytes())},
+      {core::QueryConfig::kSpillEnabled, std::to_string(getSpillEnabled())},
+      {core::QueryConfig::kJoinSpillEnabled, std::to_string(getJoinSpillEnabled())},
+      {core::QueryConfig::kAggregationSpillEnabled, std::to_string(getAggSpillEnabled())},
+      {core::QueryConfig::kOrderBySpillEnabled, std::to_string(getOrderBySpillEnabled())},
+      {core::QueryConfig::kJoinSpillMemoryThreshold,
+       std::to_string(getJoinSpillMemoryThreshold())},
+      {core::QueryConfig::kAggregationSpillMemoryThreshold,
+       std::to_string(getAggregationSpillMemoryThreshold())},
+      {core::QueryConfig::kOrderBySpillMemoryThreshold,
+       std::to_string(getJoinSpillMemoryThreshold())}};
 }
 
 std::unordered_map<std::string, std::shared_ptr<Config>>

--- a/cpp/src/NativeConfigs.h
+++ b/cpp/src/NativeConfigs.h
@@ -80,6 +80,20 @@ class NativeConfigs {
   inline const uint32_t& getMaxHttpSessionReadBufferSize() const {
     return maxHttpSessionReadBufferSize;
   }
+  inline const bool& getSpillEnabled() const { return spillEnabled; }
+  inline const bool& getJoinSpillEnabled() const { return joinSpillEnabled; }
+  inline const bool& getAggSpillEnabled() const { return aggSpillEnabled; }
+  inline const bool& getOrderBySpillEnabled() const { return orderBySpillEnabled; }
+  inline const std::string& getSpillDir() const { return spillDir; }
+  inline const uint64_t& getJoinSpillMemoryThreshold() const {
+    return joinSpillMemoryThreshold;
+  }
+  inline const uint64_t& getAggregationSpillMemoryThreshold() const {
+    return aggregationSpillMemoryThreshold;
+  }
+  inline const uint64_t& getOrderBySpillMemoryThreshold() const {
+    return orderBySpillMemoryThreshold;
+  }
 
  private:
   // refer to io.trino.operator.DirectExchangeClientConfig#maxResponseSize
@@ -114,6 +128,14 @@ class NativeConfigs {
   uint64_t initMemoryPoolCapacity = 120 << 20;
   uint64_t minMemoryPoolTransferCapacity = 32 << 20;
   uint32_t maxHttpSessionReadBufferSize = 65536;
+  bool spillEnabled = false;
+  bool joinSpillEnabled = false;
+  bool aggSpillEnabled = false;
+  bool orderBySpillEnabled = false;
+  std::string spillDir = "";
+  uint64_t joinSpillMemoryThreshold = 0;
+  uint64_t aggregationSpillMemoryThreshold = 0;
+  uint64_t orderBySpillMemoryThreshold = 0;
 };
 
 using NativeConfigsPtr = std::shared_ptr<NativeConfigs>;

--- a/cpp/src/TrinoBridge.cpp
+++ b/cpp/src/TrinoBridge.cpp
@@ -255,15 +255,8 @@ class JniHandle {
       auto task = exec::Task::create(id.fullId(), std::move(fragment), id.id(), queryCtx);
       std::string parentPath = nativeConfigs_->getSpillDir();
       if (!parentPath.empty()) {
-        if (!std::filesystem::is_directory(parentPath) ||
-            !std::filesystem::exists(parentPath)) {
-          bool ret = std::filesystem::create_directory(parentPath);
-          if (!ret) {
-            LOG(WARNING) << "Create directory " << parentPath << " failed!";
-          }
-        }
         std::string fullPath = parentPath + "/spill-" + id.fullId();
-        bool ret = std::filesystem::create_directory(fullPath);
+        bool ret = std::filesystem::create_directories(fullPath);
         if (!ret) {
           LOG(WARNING) << "Create directory " << fullPath << " failed!";
         }

--- a/cpp/src/utils/Configs.cpp
+++ b/cpp/src/utils/Configs.cpp
@@ -24,6 +24,13 @@ std::shared_ptr<folly::CPUThreadPoolExecutor> getDriverCPUExecutor(
   return executor;
 }
 
+std::shared_ptr<folly::IOThreadPoolExecutor> getSpillExecutor(size_t threadNum,
+                                                              const std::string& name) {
+  static auto executor = std::make_shared<folly::IOThreadPoolExecutor>(
+      threadNum, std::make_shared<folly::NamedThreadFactory>(name));
+  return executor;
+}
+
 std::shared_ptr<folly::IOThreadPoolExecutor> getExchangeIOCPUExecutor(
     size_t threadNum, const std::string& name) {
   static auto executor = std::make_shared<folly::IOThreadPoolExecutor>(

--- a/cpp/src/utils/Configs.h
+++ b/cpp/src/utils/Configs.h
@@ -383,7 +383,7 @@ std::shared_ptr<folly::CPUThreadPoolExecutor> getDriverCPUExecutor(
     size_t threadNum = 8, const std::string& name = "Driver");
 
 std::shared_ptr<folly::IOThreadPoolExecutor> getExchangeIOCPUExecutor(
-    size_t threadNum = 8, const std::string& name = "ExchangeIO");
+    size_t threadNum = 8, const std::string& name = "SpillIO");
 
 std::shared_ptr<folly::IOThreadPoolExecutor> getSpillExecutor(
     size_t threadNum = 8, const std::string& name = "ExchangeIO");

--- a/cpp/src/utils/Configs.h
+++ b/cpp/src/utils/Configs.h
@@ -383,10 +383,10 @@ std::shared_ptr<folly::CPUThreadPoolExecutor> getDriverCPUExecutor(
     size_t threadNum = 8, const std::string& name = "Driver");
 
 std::shared_ptr<folly::IOThreadPoolExecutor> getExchangeIOCPUExecutor(
-    size_t threadNum = 8, const std::string& name = "SpillIO");
+    size_t threadNum = 8, const std::string& name = "ExchangeIO");
 
 std::shared_ptr<folly::IOThreadPoolExecutor> getSpillExecutor(
-    size_t threadNum = 8, const std::string& name = "ExchangeIO");
+    size_t threadNum = 8, const std::string& name = "SpillIO");
 
 std::shared_ptr<folly::IOThreadPoolExecutor> getConnectorIOExecutor(
     size_t threadNum = 8, const std::string& name = "ConnectorIO");

--- a/cpp/src/utils/Configs.h
+++ b/cpp/src/utils/Configs.h
@@ -385,6 +385,9 @@ std::shared_ptr<folly::CPUThreadPoolExecutor> getDriverCPUExecutor(
 std::shared_ptr<folly::IOThreadPoolExecutor> getExchangeIOCPUExecutor(
     size_t threadNum = 8, const std::string& name = "ExchangeIO");
 
+std::shared_ptr<folly::IOThreadPoolExecutor> getSpillExecutor(
+    size_t threadNum = 8, const std::string& name = "ExchangeIO");
+
 std::shared_ptr<folly::IOThreadPoolExecutor> getConnectorIOExecutor(
     size_t threadNum = 8, const std::string& name = "ConnectorIO");
 }  // namespace io::trino::bridge

--- a/java/src/main/java/io/trino/velox/NativeConfigs.java
+++ b/java/src/main/java/io/trino/velox/NativeConfigs.java
@@ -44,6 +44,14 @@ public class NativeConfigs
     private final long initMemoryPoolCapacity;
     private final long minMemoryPoolTransferCapacity;
     private final int maxHttpSessionReadBufferSize;
+    private final boolean joinSpillEnabled;
+    private final boolean aggSpillEnabled;
+    private final boolean orderBySpillEnabled;
+    private final boolean spillEnabled;
+    private final String spillDir;
+    private final long aggregationSpillMemoryThreshold;
+    private final long joinSpillMemoryThreshold;
+    private final long orderBySpillMemoryThreshold;
 
     @Inject
     public NativeConfigs(
@@ -72,7 +80,15 @@ public class NativeConfigs
                 nativeTaskConfig.getReservedMemoryPoolCapacityPercentage(),
                 nativeTaskConfig.getInitMemoryPoolCapacity(),
                 nativeTaskConfig.getMinMemoryPoolTransferCapacity(),
-                nativeTaskConfig.getMaxHttpSessionReadBufferSize());
+                nativeTaskConfig.getMaxHttpSessionReadBufferSize(),
+                nativeTaskConfig.isSpillEnabled(),
+                nativeTaskConfig.isJoinSpillEnabled(),
+                nativeTaskConfig.isAggSpillEnabled(),
+                nativeTaskConfig.isOrderBySpillEnabled(),
+                nativeTaskConfig.getSpillDir(),
+                nativeTaskConfig.getJoinSpillMemoryThreshold(),
+                nativeTaskConfig.getAggregationSpillMemoryThreshold(),
+                nativeTaskConfig.getOrderBySpillMemoryThreshold());
     }
 
     @JsonCreator
@@ -98,7 +114,15 @@ public class NativeConfigs
             @JsonProperty int reservedMemoryPoolCapacityPercentage,
             @JsonProperty long initMemoryPoolCapacity,
             @JsonProperty long minMemoryPoolTransferCapacity,
-            @JsonProperty int maxHttpSessionReadBufferSize)
+            @JsonProperty int maxHttpSessionReadBufferSize,
+            @JsonProperty boolean spillEnabled,
+            @JsonProperty boolean joinSpillEnabled,
+            @JsonProperty boolean aggSpillEnabled,
+            @JsonProperty boolean orderBySpillEnabled,
+            @JsonProperty String spillDir,
+            @JsonProperty long joinSpillMemoryThreshold,
+            @JsonProperty long aggregationSpillMemoryThreshold,
+            @JsonProperty long orderBySpillMemoryThreshold)
     {
         this.maxOutputPageBytes = maxOutputPageBytes;
         this.maxWorkerThreads = maxWorkerThreads;
@@ -122,6 +146,14 @@ public class NativeConfigs
         this.initMemoryPoolCapacity = initMemoryPoolCapacity;
         this.minMemoryPoolTransferCapacity = minMemoryPoolTransferCapacity;
         this.maxHttpSessionReadBufferSize = maxHttpSessionReadBufferSize;
+        this.spillEnabled = spillEnabled;
+        this.joinSpillEnabled = joinSpillEnabled;
+        this.aggSpillEnabled = aggSpillEnabled;
+        this.orderBySpillEnabled = orderBySpillEnabled;
+        this.spillDir = spillDir;
+        this.joinSpillMemoryThreshold = joinSpillMemoryThreshold;
+        this.aggregationSpillMemoryThreshold = aggregationSpillMemoryThreshold;
+        this.orderBySpillMemoryThreshold = orderBySpillMemoryThreshold;
     }
 
     @JsonProperty
@@ -254,5 +286,53 @@ public class NativeConfigs
     public int getMaxHttpSessionReadBufferSize()
     {
         return maxHttpSessionReadBufferSize;
+    }
+
+    @JsonProperty
+    public boolean getSpillEnabled()
+    {
+        return spillEnabled;
+    }
+
+    @JsonProperty
+    public boolean getJoinSpillEnabled()
+    {
+        return joinSpillEnabled;
+    }
+
+    @JsonProperty
+    public boolean getAggSpillEnabled()
+    {
+        return aggSpillEnabled;
+    }
+
+    @JsonProperty
+    public boolean getOrderBySpillEnabled()
+    {
+        return orderBySpillEnabled;
+    }
+
+    @JsonProperty
+    public String getSpillDir()
+    {
+        return spillDir;
+    }
+
+    @JsonProperty
+    public long getAggregationSpillMemoryThreshold()
+    {
+        return aggregationSpillMemoryThreshold;
+    }
+
+    @JsonProperty
+    public long getJoinSpillMemoryThreshold()
+    {
+        return joinSpillMemoryThreshold;
+    }
+
+    @JsonProperty
+    public long getOrderBySpillMemoryThreshold()
+    {
+        return orderBySpillMemoryThreshold;
     }
 }

--- a/java/src/main/java/io/trino/velox/NativeTaskConfig.java
+++ b/java/src/main/java/io/trino/velox/NativeTaskConfig.java
@@ -46,7 +46,7 @@ public class NativeTaskConfig
     private boolean aggSpillEnabled;
     private boolean orderBySpillEnabled;
     private boolean spillEnabled;
-    private String spillDir;
+    private String spillDir = "";
     private long aggregationSpillMemoryThreshold;
     private long joinSpillMemoryThreshold;
     private long orderBySpillMemoryThreshold;

--- a/java/src/main/java/io/trino/velox/NativeTaskConfig.java
+++ b/java/src/main/java/io/trino/velox/NativeTaskConfig.java
@@ -42,6 +42,15 @@ public class NativeTaskConfig
     private long minMemoryPoolTransferCapacity = 32 << 20;
     private int maxHttpSessionReadBufferSize = 64 << 10;
 
+    private boolean joinSpillEnabled;
+    private boolean aggSpillEnabled;
+    private boolean orderBySpillEnabled;
+    private boolean spillEnabled;
+    private String spillDir;
+    private long aggregationSpillMemoryThreshold;
+    private long joinSpillMemoryThreshold;
+    private long orderBySpillMemoryThreshold;
+
     @NotNull
     public String getLogVerboseModules()
     {
@@ -260,6 +269,110 @@ public class NativeTaskConfig
     public NativeTaskConfig setMaxHttpSessionReadBufferSize(int maxHttpSessionReadBufferSize)
     {
         this.maxHttpSessionReadBufferSize = maxHttpSessionReadBufferSize;
+        return this;
+    }
+
+    @NotNull
+    public boolean isJoinSpillEnabled()
+    {
+        return joinSpillEnabled;
+    }
+
+    @NotNull
+    public boolean isAggSpillEnabled()
+    {
+        return aggSpillEnabled;
+    }
+
+    @NotNull
+    public boolean isOrderBySpillEnabled()
+    {
+        return orderBySpillEnabled;
+    }
+
+    @NotNull
+    public boolean isSpillEnabled()
+    {
+        return spillEnabled;
+    }
+
+    @NotNull
+    public String getSpillDir()
+    {
+        return spillDir;
+    }
+
+    @NotNull
+    public long getAggregationSpillMemoryThreshold()
+    {
+        return aggregationSpillMemoryThreshold;
+    }
+
+    @NotNull
+    public long getJoinSpillMemoryThreshold()
+    {
+        return joinSpillMemoryThreshold;
+    }
+
+    @NotNull
+    public long getOrderBySpillMemoryThreshold()
+    {
+        return orderBySpillMemoryThreshold;
+    }
+
+    @Config("native.agg-spill-enabled")
+    public NativeTaskConfig setAggSpillEnabled(boolean aggSpillEnabled)
+    {
+        this.aggSpillEnabled = aggSpillEnabled;
+        return this;
+    }
+
+    @Config("native.join-spill-enabled")
+    public NativeTaskConfig setJoinSpillEnabled(boolean joinSpillEnabled)
+    {
+        this.joinSpillEnabled = joinSpillEnabled;
+        return this;
+    }
+
+    @Config("native.orderby-spill-enabled")
+    public NativeTaskConfig setOrderBySpillEnabled(boolean orderBySpillEnabled)
+    {
+        this.orderBySpillEnabled = orderBySpillEnabled;
+        return this;
+    }
+
+    @Config("native.spill-enabled")
+    public NativeTaskConfig setSpillEnabled(boolean spillEnabled)
+    {
+        this.spillEnabled = spillEnabled;
+        return this;
+    }
+
+    @Config("native.spill-dir")
+    public NativeTaskConfig setSpillDir(String spillDir)
+    {
+        this.spillDir = spillDir;
+        return this;
+    }
+
+    @Config("native.agg-spill-memory-threshold")
+    public NativeTaskConfig setAggregationSpillMemoryThreshold(long aggregationSpillMemoryThreshold)
+    {
+        this.aggregationSpillMemoryThreshold = aggregationSpillMemoryThreshold;
+        return this;
+    }
+
+    @Config("native.join-spill-memory-threshold")
+    public NativeTaskConfig setJoinSpillMemoryThreshold(long joinSpillMemoryThreshold)
+    {
+        this.joinSpillMemoryThreshold = joinSpillMemoryThreshold;
+        return this;
+    }
+
+    @Config("native.orderby-spill-memory-threshold")
+    public NativeTaskConfig setOrderBySpillMemoryThreshold(long orderBySpillMemoryThreshold)
+    {
+        this.orderBySpillMemoryThreshold = orderBySpillMemoryThreshold;
         return this;
     }
 }

--- a/java/src/main/java/io/trino/velox/execution/NativeSqlTaskExecution.java
+++ b/java/src/main/java/io/trino/velox/execution/NativeSqlTaskExecution.java
@@ -314,7 +314,6 @@ public class NativeSqlTaskExecution
         outputBuffer.enqueue(partitionId, outputs);
         long prev = partitionSequenceId[partitionId];
         partitionSequenceId[partitionId] += outputs.size();
-//        logger.info("Advanced sequenceId of output partition %d from %d to %d.", partitionId, prev, partitionSequenceId[partitionId]);
     }
 
     public ListenableFuture<Void> isOutputBufferFull()

--- a/java/src/main/java/io/trino/velox/execution/NativeSqlTaskExecution.java
+++ b/java/src/main/java/io/trino/velox/execution/NativeSqlTaskExecution.java
@@ -14,6 +14,7 @@
 package io.trino.velox.execution;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.SetThreadName;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
@@ -313,7 +314,12 @@ public class NativeSqlTaskExecution
         outputBuffer.enqueue(partitionId, outputs);
         long prev = partitionSequenceId[partitionId];
         partitionSequenceId[partitionId] += outputs.size();
-        logger.info("Advanced sequenceId of output partition %d from %d to %d.", partitionId, prev, partitionSequenceId[partitionId]);
+//        logger.info("Advanced sequenceId of output partition %d from %d to %d.", partitionId, prev, partitionSequenceId[partitionId]);
+    }
+
+    public ListenableFuture<Void> isOutputBufferFull()
+    {
+        return outputBuffer.isFull();
     }
 
     private static final class CheckTaskCompletionOnBufferFinish


### PR DESCRIPTION
enable velox spill via below configs:
`native.spill-enabled` global control enable or disable spill.
`native.spill-dir` directory for spill files.
`native.agg-spill-enabled`, `native.agg-spill-memory-threshold` control aggregation operator spill or not, and its threshold.
`native.join-spill-memory-threshold`, `native.agg-spill-memory-threshold` control join operator(HashBuild and HashProbe) spill or not, and its threshold.
`native.orderby-spill-enabled`, `native.orderby-spill-memory-threshold` control OrderBy operator spill or not, and its threshold.
