### PR TITLE
Do not cast constant expression

### DIFF
--- a/java/src/main/java/io/trino/velox/protocol/ExpressionTranslator.java
+++ b/java/src/main/java/io/trino/velox/protocol/ExpressionTranslator.java
@@ -209,6 +209,9 @@ public final class ExpressionTranslator
         {
             requireNonNull(toType, "toType is null.");
             requireNonNull(node, "node is null.");
+            if (node instanceof GlutenConstantExpression) {
+                return node;
+            }
             if (!toType.equals(node.getType())) {
                 String displayName = "CAST";
                 GlutenSignature newSignature = new GlutenSignature(


### PR DESCRIPTION
It may cause error transferring constant expression to call expression, especially in decimal casting.

It will fix TPC-DS query61&query 83.